### PR TITLE
fix: safely stop nodes by pid

### DIFF
--- a/apps/anoma_node/lib/supervisor.ex
+++ b/apps/anoma_node/lib/supervisor.ex
@@ -75,9 +75,14 @@ defmodule Anoma.Supervisor do
   """
   @spec stop_node(String.t()) :: :ok
   def stop_node(node_id) do
-    Anoma.Node.Registry.via(node_id, Anoma.Node.Supervisor)
+    case Anoma.Node.Registry.whereis(node_id, Anoma.Node.Supervisor) do
+      nil ->
+        :ok
 
-    Supervisor.stop(Anoma.Node.Registry.via(node_id, Anoma.Node.Supervisor))
+      pid when is_pid(pid) ->
+        Supervisor.stop(pid)
+        :ok
+    end
   end
 
   ############################################################

--- a/apps/anoma_node/test/supervisor_test.exs
+++ b/apps/anoma_node/test/supervisor_test.exs
@@ -1,0 +1,27 @@
+defmodule Anoma.SupervisorTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    {:ok, sup} = Anoma.Supervisor.start_link([])
+    on_exit(fn -> Supervisor.stop(sup) end)
+    :ok
+  end
+
+  test "stop_node returns :ok when node is unknown" do
+    assert :ok = Anoma.Supervisor.stop_node("unknown-node")
+  end
+
+  test "stop_node stops a running node" do
+    node_id = Base.encode16(:crypto.strong_rand_bytes(8))
+
+    {:ok, _pid} =
+      Anoma.Supervisor.start_node(node_id: node_id, transaction: [mempool: []])
+
+    pid = Anoma.Node.Registry.whereis(node_id, Anoma.Node.Supervisor)
+    assert is_pid(pid)
+
+    assert :ok = Anoma.Supervisor.stop_node(node_id)
+    refute Process.alive?(pid)
+  end
+end
+


### PR DESCRIPTION
## Summary
- safely handle unknown nodes when stopping
- test supervisor stop_node behavior

## Testing
- `MIX_REBAR=/root/.mix/rebar3 MIX_REBAR3=/root/.mix/rebar3 mix test apps/anoma_node/test/supervisor_test.exs` *(fails: dependency missing)*